### PR TITLE
Fix news page

### DIFF
--- a/lib/data/farm/models/News.dart
+++ b/lib/data/farm/models/News.dart
@@ -105,7 +105,7 @@ class Source {
   String toRawJson() => json.encode(toJson());
 
   factory Source.fromJson(Map<String, dynamic> json) => Source(
-        id: json["id"] == null ? '' : json["id"],
+        id: json["id"] == null ? "" : json["id"],
         name: json["name"] == null ? null : json["name"],
       );
 

--- a/lib/data/farm/models/News.dart
+++ b/lib/data/farm/models/News.dart
@@ -59,13 +59,13 @@ class Article {
 
   factory Article.fromJson(Map<String, dynamic> json) => Article(
         source: Source.fromJson(json["source"]),
-        author: json["author"] == null ? null : json["author"],
-        title: json["title"] == null ? null : json["title"],
-        description: json["description"] == null ? null : json["description"],
-        url: json["url"] == null ? null : json["url"],
-        urlToImage: json["urlToImage"] == null ? null : json["urlToImage"],
+        author: json["author"] == null ? "" : json["author"],
+        title: json["title"] == null ? "" : json["title"],
+        description: json["description"] == null ? "" : json["description"],
+        url: json["url"] == null ? "" : json["url"],
+        urlToImage: json["urlToImage"] == null ? "" : json["urlToImage"],
         publishedAt: DateTime.parse(json["publishedAt"]),
-        content: json["content"] == null ? null : json["content"],
+        content: json["content"] == null ? "" : json["content"],
       );
 
   Map<String, dynamic> toJson() => {
@@ -105,7 +105,7 @@ class Source {
   String toRawJson() => json.encode(toJson());
 
   factory Source.fromJson(Map<String, dynamic> json) => Source(
-        id: json["id"] == null ? null : json["id"],
+        id: json["id"] == null ? '' : json["id"],
         name: json["name"] == null ? null : json["name"],
       );
 

--- a/lib/ui/farm/news/bloc/nBloc.dart
+++ b/lib/ui/farm/news/bloc/nBloc.dart
@@ -17,7 +17,6 @@ class NewsBloc extends Bloc<NewsEvent, NewsState> {
         final items = await repository.fetchAllNews(category: event.category);
         emit(Loaded(items: items, type: event.category));
       } catch (ex) {
-        debugPrint(ex.toString());
         emit(Failure());
       }
     });

--- a/lib/ui/farm/news/bloc/nBloc.dart
+++ b/lib/ui/farm/news/bloc/nBloc.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:farmassist/data/farm/resources/repository.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'nEvent.dart';
@@ -9,19 +10,18 @@ import 'nState.dart';
 class NewsBloc extends Bloc<NewsEvent, NewsState> {
   final Repository repository;
 
-  NewsBloc({required this.repository}) : super(Loading());
+  NewsBloc({required this.repository}) : super(Loading()){
+    on<Fetch>((event, emit) async {
+      try {
+        emit(Loading());
+        final items = await repository.fetchAllNews(category: event.category);
+        emit(Loaded(items: items, type: event.category));
+      } catch (ex) {
+        debugPrint(ex.toString());
+        emit(Failure());
+      }
+    });
+  }
 
   NewsState get initialState => Loading();
-
-  Stream<NewsState> mapEventToState(NewsEvent event) async* {
-    if (event is Fetch) {
-      try {
-        yield Loading();
-        final items = await repository.fetchAllNews(category: event.category);
-        yield Loaded(items: items, type: event.category);
-      } catch (_) {
-        yield Failure();
-      }
-    }
-  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -446,6 +446,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.3"
+  flutter_screenutil:
+    dependency: "direct main"
+    description:
+      name: flutter_screenutil
+      sha256: "1b61f8c4cbf965104b6ca7160880ff1af6755aad7fec70b58444245132453745"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.4"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -599,6 +607,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: "6b6f10f0ce3c42f6552d1c70d2c28d764cf22bb487f50f66cca31dcd5194f4d6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.4"
   google_identity_services_web:
     dependency: transitive
     description:


### PR DESCRIPTION
# Background

![image](https://github.com/c1scok1d/farmassist-master-06192023/assets/54102433/53dc6577-0f4d-41e5-9f4a-4d27d9217acd)


# Description

This PR:
* Fixes news page
   * `mapEventToState` has been removed in bloc v8. It needs to be migrated. This PR only fixes `NewsBloc`. You can find the guide [here](https://bloclibrary.dev/#/migration?id=v720).
* Fixes deserialization (`fromJson`) for news related models.
   * Sets `""` as default for String type. 

# Screen recording

[demo.webm](https://github.com/c1scok1d/farmassist-master-06192023/assets/54102433/a8a665c7-fc93-4271-b357-3702c422fc8e)
